### PR TITLE
Support Gnome 47

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -2,7 +2,7 @@
 	"uuid": "viewsplit@model-map.github.io",
 	"name": "View Split",
 	"description": "Maximize your productivity with View Split, the window management tool that allows you to split windows into top, left, bottom, and right sections",
-	"version": 1,
-	"shell-version": ["42","43", "44","45"],
+	"version": 9,
+	"shell-version": ["42","43", "44","45", "46", "47"],
 	"url": "https://github.com/model-map/view-split-gnome-extension"
 }

--- a/prefs.js
+++ b/prefs.js
@@ -1,146 +1,98 @@
-// Mostly taken from https://raw.githubusercontent.com/gTile/gTile and https://github.com/shiznatix/bifocals-gnome-extension/
-// Slightly modified but all real credit goes to gTitle and BiFocals!
+import Adw from 'gi://Adw';
+import Gtk from 'gi://Gtk';
+import GObject from 'gi://GObject';
+import {ExtensionPreferences, gettext as _} from 'resource:///org/gnome/Shell/Extensions/js/extensions/prefs.js';
 
-const GObject = imports.gi.GObject;
-const Gtk = imports.gi.Gtk;
-
-const ExtensionUtils = imports.misc.extensionUtils;
 const prettyNames = {
-	'toggle-left': 'Split view Left',
-	'toggle-right': 'Split view Right',
-	'toggle-top': 'Split view Top',
-	'toggle-bottom': 'Split view Bottom'
+    'toggle-left': 'Split view Left',
+    'toggle-right': 'Split view Right',
+    'toggle-top': 'Split view Top',
+    'toggle-bottom': 'Split view Bottom',
 };
 
-// eslint-disable-next-line no-unused-vars
-function init() {
-}
+export default class ViewSplitPreferences extends ExtensionPreferences {
+    fillPreferencesWindow(window) {
+        const settings = this.getSettings('org.gnome.shell.extensions.viewsplit');
 
-function appendHotkey(model, settings, name, prettyName) {
-	let key, mods, _;
+        const page = new Adw.PreferencesPage();
+        const group = new Adw.PreferencesGroup({
+            title: _('Keyboard Shortcuts'),
+        });
 
-	if (Gtk.get_major_version() >= 4) {
-		// ignore ok as failure treated as disabled
-		[_, key, mods] = Gtk.accelerator_parse(settings.get_strv(name)[0]);
-	} else {
-		[key, mods] = Gtk.accelerator_parse(settings.get_strv(name)[0]);
-	}
+        const model = new Gtk.ListStore();
+        model.set_column_types([
+            GObject.TYPE_STRING,
+            GObject.TYPE_STRING,
+            GObject.TYPE_INT,
+            GObject.TYPE_INT,
+        ]);
 
-	const row = model.insert(-1);
+        for (const key in prettyNames) {
+            this.appendHotkey(model, settings, key, prettyNames[key]);
+        }
 
-	model.set(row, [0, 1, 2, 3], [name, prettyName, mods, key]);
-}
+        const treeview = new Gtk.TreeView({
+            model,
+            hexpand: true,
+            vexpand: true,
+        });
 
-function setChild(widget, child) {
-	if (Gtk.get_major_version() >= 4) {
-		widget.set_child(child);
-	} else {
-		widget.add(child);
-	}
-}
+        const renderShortcutTitle = new Gtk.CellRendererText();
+        const colShortcutTitle = new Gtk.TreeViewColumn({
+            title: _('Keybinding'),
+            expand: true,
+        });
+        colShortcutTitle.pack_start(renderShortcutTitle, true);
+        colShortcutTitle.add_attribute(renderShortcutTitle, 'text', 1);
+        treeview.append_column(colShortcutTitle);
 
-// eslint-disable-next-line no-unused-vars
-function buildPrefsWidget() {
-	const settings = ExtensionUtils.getSettings('org.gnome.shell.extensions.viewsplit');
-	const grid = new Gtk.Grid({
-		column_spacing: 10,
-		orientation: Gtk.Orientation.VERTICAL,
-		row_spacing: 10,
-		visible: true,
-	});
+        const renderKeybinding = new Gtk.CellRendererAccel({
+            'editable': true,
+            'accel-mode': Gtk.CellRendererAccelMode.GTK,
+        });
 
-	grid.set_margin_start(24);
-	grid.set_margin_top(24);
+        renderKeybinding.connect('accel-cleared', (rend, strIter) => {
+            const [success, iter] = model.get_iter_from_string(strIter);
+            if (!success) return;
 
-	const model = new Gtk.ListStore();
+            const name = model.get_value(iter, 0);
+            model.set(iter, [3], [0]);
+            settings.set_strv(name, ['']);
+        });
 
-	model.set_column_types([
-		GObject.TYPE_STRING,
-		GObject.TYPE_STRING,
-		GObject.TYPE_INT,
-		GObject.TYPE_INT,
-	]);
+        renderKeybinding.connect('accel-edited', (rend, strIter, key, mods) => {
+            const value = Gtk.accelerator_name(key, mods);
+            const [success, iter] = model.get_iter_from_string(strIter);
+            if (!success) return;
 
-	for (const key in prettyNames) {
-		appendHotkey(model, settings, key, prettyNames[key]);
-	}
+            const name = model.get_value(iter, 0);
+            model.set(iter, [2, 3], [mods, key]);
+            settings.set_strv(name, [value]);
+        });
 
-	const treeview = new Gtk.TreeView({
-		model,
-		hexpand: true,
-		visible: true,
-	});
+        const colKeybinding = new Gtk.TreeViewColumn({
+            title: _('Accel'),
+        });
+        colKeybinding.pack_end(renderKeybinding, false);
+        colKeybinding.add_attribute(renderKeybinding, 'accel-mods', 2);
+        colKeybinding.add_attribute(renderKeybinding, 'accel-key', 3);
+        treeview.append_column(colKeybinding);
 
-	const renderShotcutTitle = new Gtk.CellRendererText();
-	const colShortcutTitle = new Gtk.TreeViewColumn({
-		title: 'Keybinding',
-		expand: true,
-	});
+        group.add(treeview);
+        page.add(group);
+        window.add(page);
+    }
 
-	colShortcutTitle.pack_start(renderShotcutTitle, true);
-	colShortcutTitle.add_attribute(renderShotcutTitle, 'text', 1);
+    appendHotkey(model, settings, name, prettyName) {
+        let key, mods, _;
 
-	treeview.append_column(colShortcutTitle);
+        if (Gtk.get_major_version() >= 4) {
+            [_, key, mods] = Gtk.accelerator_parse(settings.get_strv(name)[0] || '');
+        } else {
+            [key, mods] = Gtk.accelerator_parse(settings.get_strv(name)[0] || '');
+        }
 
-	const renderKeybinding = new Gtk.CellRendererAccel({
-		'editable': true,
-		'accel-mode': Gtk.CellRendererAccelMode.GTK,
-	});
-	renderKeybinding.connect('accel-cleared', (rend, strIter) => {
-		const [success, iter] = model.get_iter_from_string(strIter);
-
-		if (!success) {
-			throw new Error('Something went wrong trying to clear the accel');
-		}
-
-		const name = model.get_value(iter, 0);
-		model.set(iter, [3], [0]);
-		settings.set_strv(name, ['']);
-	});
-	renderKeybinding.connect('accel-edited', (rend, strIter, key, mods) => {
-		const value = Gtk.accelerator_name(key, mods);
-
-		const [success, iter] = model.get_iter_from_string(strIter);
-
-		if (!success) {
-			throw new Error('Something went wrong trying to set the accel');
-		}
-
-		const name = model.get_value(iter, 0);
-
-		model.set(iter, [ 2, 3 ], [ mods, key ]);
-
-		settings.set_strv(name, [value]);
-	});
-
-	const colKeybinding = new Gtk.TreeViewColumn({
-		title: 'Accel',
-	});
-
-	colKeybinding.pack_end(renderKeybinding, false);
-	colKeybinding.add_attribute(renderKeybinding, 'accel-mods', 2);
-	colKeybinding.add_attribute(renderKeybinding, 'accel-key', 3);
-
-	treeview.append_column(colKeybinding);
-
-	const shortcutsLabel = new Gtk.Label({
-		label: 'Keyboard shortcuts',
-		halign: Gtk.Align.START,
-		justify: Gtk.Justification.LEFT,
-		use_markup: false,
-		wrap: true,
-		visible: true,
-	});
-
-	grid.attach_next_to(shortcutsLabel, null, Gtk.PositionType.BOTTOM, 1, 1);
-	grid.attach_next_to(treeview, null, Gtk.PositionType.BOTTOM, 1, 1);
-
-	const scrollWindow = new Gtk.ScrolledWindow({
-		vexpand: true,
-		visible: true,
-	});
-
-	setChild(scrollWindow, grid);
-
-	return scrollWindow;
+        const row = model.insert(-1);
+        model.set(row, [0, 1, 2, 3], [name, prettyName, mods, key]);
+    }
 }


### PR DESCRIPTION
Refactor extension to ES6 and support Gnome 47

The code has been refactored to use ES6 syntax, including the use of import statements and class-based structure. The extension now supports Gnome versions up to 47.